### PR TITLE
Actually do something if user returns None

### DIFF
--- a/engine/api.py
+++ b/engine/api.py
@@ -158,6 +158,7 @@ class SubmitResource(object):
             if user_output[0] is None:
                 logger.debug("Looks like user's function returned None: output={:}".format(user_output))
                 passed = False
+                expected_output = "Your function returned None. It shouldn't do that."
             else:
                 try:
                     passed, expected_output = problem.verify_user_solution(input_tuple, user_output)


### PR DESCRIPTION
Kind of a hack but instead of doing nothing but spinning (current behavior), we now say "Your function returned None. It shouldn't do that." in the expected output if user returns None