### PR TITLE
C support

### DIFF
--- a/engine/api.py
+++ b/engine/api.py
@@ -231,7 +231,7 @@ def write_code_to_file(code, language):
     :return: the name of the file containing the user's code
     """
     decoded_code = str(base64.b64decode(code), 'utf-8')
-    extension = {'python': '.py', 'julia': '.jl', 'javascript': '.js'}.get(language)
+    extension = {'python': ".py", 'javascript': ".js", 'julia': ".jl", 'c': ".c"}.get(language)
     code_filename = util.write_str_to_file(decoded_code, extension)
 
     logger.debug("User code saved in: {:s}".format(code_filename))

--- a/engine/api.py
+++ b/engine/api.py
@@ -125,7 +125,8 @@ class SubmitResource(object):
 
         try:
             input_tuples = [tc.input_tuple() for tc in test_cases]
-            user_outputs, p_infos = runner.run(self.container_name, code_filename, function_name, input_tuples)
+            output_tuples = [tc.output_tuple() for tc in test_cases]
+            user_outputs, p_infos = runner.run(self.container_name, code_filename, function_name, input_tuples, output_tuples)
 
         except (FilePushError, FilePullError):
             explanation = "File could not be pushed to or pulled from LXD container. Returning falcon HTTP 500."
@@ -161,7 +162,7 @@ class SubmitResource(object):
                 expected_output = "Your function returned None. It shouldn't do that."
             else:
                 try:
-                    passed, expected_output = problem.verify_user_solution(input_tuple, user_output)
+                    passed, expected_output = problem.verify_user_solution(tc, input_tuple, user_output)
                 except Exception:
                     explanation = "Internal engine error during user test case verification. Returning falcon HTTP 500."
                     add_error_to_response(resp, explanation, traceback.format_exc(), falcon.HTTP_500, code_filename)

--- a/engine/code_runner.py
+++ b/engine/code_runner.py
@@ -27,13 +27,14 @@ class FilePullError(Exception):
 
 class AbstractRunner(metaclass=ABCMeta):
     @abstractmethod
-    def run(self, container_name, filename, function_name, input_str):
+    def run(self, container_name, filename, function_name, input_tuples, output_tuples):
         """Execute the given file using input_str as input through stdin and return the program's output."""
 
 
 class CodeRunner(AbstractRunner):
     def __init__(self, language):
         self.util_files = []
+        self.push_correct_output = False
 
         if language == "python":
             self.run_script_filename = "run_py.py"
@@ -44,10 +45,11 @@ class CodeRunner(AbstractRunner):
             self.util_files.append("julia_runner_util.jl")
         elif language == "c":
             self.run_script_filename = "run_c.py"
+            self.push_correct_output = True
         else:
             raise ValueError("CodeRunner does not support language={:}".format(language))
 
-    def run(self, container_name, code_filename, function_name, input_tuples):
+    def run(self, container_name, code_filename, function_name, input_tuples, correct_output_tuples):
         logger.info("Running {:s} with {:d} inputs...".format(code_filename, len(input_tuples)))
 
         run_id = code_filename.split('.')[0]
@@ -71,6 +73,14 @@ class CodeRunner(AbstractRunner):
 
         # Push all the files we need into the Linux container.
         required_files = [code_filename, runner_file, input_pickle]
+        if self.push_correct_output:
+            correct_output_pickle = "{:s}.correct.pickle".format(run_id)
+            with open(correct_output_pickle, mode='wb') as f:
+                logger.debug("Pickling correct output tuples in {:s}...".format(correct_output_pickle))
+                pickle.dump(correct_output_tuples, file=f, protocol=pickle.HIGHEST_PROTOCOL)
+
+            required_files.append(correct_output_pickle)
+
         for file_name in required_files + self.util_files:
             source_path = file_name
             target_path = "/root/{:s}".format(file_name)

--- a/engine/code_runner.py
+++ b/engine/code_runner.py
@@ -42,6 +42,8 @@ class CodeRunner(AbstractRunner):
         elif language == "julia":
             self.run_script_filename = "run_jl.py"
             self.util_files.append("julia_runner_util.jl")
+        elif language == "c":
+            self.run_script_filename = "run_c.py"
         else:
             raise ValueError("CodeRunner does not support language={:}".format(language))
 

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -85,8 +85,6 @@ def preprocess_types(input_tuple, output_tuple):
 
             output_list.append(arr)
 
-            output_list.append(arr)
-
         elif isinstance(rvar, ndarray):
             arr_ctype = ndpointer(dtype=rvar.dtype, ndim=len(rvar.shape), shape=rvar.shape, flags="C_CONTIGUOUS")
             arg_ctypes.append(arr_ctype)

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -3,25 +3,54 @@ import ctypes
 import pickle
 import subprocess
 
+def infer_ctype(var):
+    if isinstance(var, int):
+        return ctypes.c_int
+    elif isinstance(var, float):
+        return ctypes.c_double
+    elif isinstance(var, str):
+        return ctypes.c_char_p
+    else:
+        raise NotImplementedError("Cannot infer ctype of type(var)={:}, var={:}".format(type(var), var))
+
 def infer_argtypes(input_tuple):
     arg_ctypes = []
     for var in input_tuple:
-        if isinstance(var, int):
-            arg_ctypes.append(ctypes.c_int)
-        elif isinstance(var, float):
-            arg_ctypes.append(ctypes.c_double)
-        elif isinstance(var, str):
-            arg_ctypes.append(ctypes.c_char_p)
-
+        arg_ctypes.append(infer_ctype(var))
     return arg_ctypes
+
+def infer_restype(output_tuple):
+    if len(output_tuple) > 1:
+        raise NotImplementedError("C does not support multiple return values but len(output_tuple)={:d}"
+                                  .format(len(output_tuple)))
+    return infer_ctype(output_tuple[0])
+
+def ctype_input_list(input_tuple):
+    input_list = []
+    for k, var in enumerate(input_tuple):
+        if isinstance(var, str):
+            input_list.append(ctypes.c_char_p(bytes(var, "utf-8")))
+        else:
+            input_list.append(var)
+    return input_list
+
+def ctype_output(var, correct_output):
+    if isinstance(correct_output, str):
+        return var.decode("utf-8")
+    else:
+        return var
 
 run_id = os.path.basename(__file__).split('.')[0]
 input_pickle = "{:s}.input.pickle".format(run_id)
+correct_pickle = "{:s}.correct.pickle".format(run_id)
 code_file = "{:s}.c".format(run_id)
 lib_file = "{:s}.so".format(run_id)
 
 with open(input_pickle, mode='rb') as f:
     input_tuples = pickle.load(f)
+
+with open(correct_pickle, mode='rb') as f:
+    correct_output_tuples = pickle.load(f)
 
 # Compile the user's C code.
 # -fPIC for position-independent code, needed for shared libraries to work no matter where in memory they are loaded.
@@ -33,14 +62,18 @@ subprocess.run(["gcc", "-fPIC", "-shared", "-o", lib_file, code_file], check=Tru
 cwd = os.path.dirname(os.path.realpath(__file__))
 lib = ctypes.cdll.LoadLibrary(os.path.join(cwd, lib_file))
 
-# Use the first input tuple to infer the type of input arguments.
-lib.$FUNCTION_NAME.argtypes = infer_argtypes(input_tuples[0])
+for i, (input_tuple, correct_output_tuple) in enumerate(zip(input_tuples, correct_output_tuples)):
+    # Use the input and output tuple to infer the type of input arguments and return value. We do this again for each
+    # test case in case outputs change type or arrays change size.
+    lib.$FUNCTION_NAME.argtypes = infer_argtypes(input_tuple)
+    lib.$FUNCTION_NAME.restype = infer_restype(correct_output_tuple)
 
-lib.$FUNCTION_NAME.restype = ctypes.c_double
+    ctyped_input_list = ctype_input_list(input_tuple)
 
-for i, input_tuple in enumerate(input_tuples):
     # $FUNCTION_NAME will be replaced by the name of the user's function by the CodeRunner before this script is run.
-    user_output = lib.$FUNCTION_NAME(*input_tuple)
+    user_output = lib.$FUNCTION_NAME(*ctyped_input_list)
+
+    user_output = ctype_output(user_output, correct_output_tuple[0])
 
     output_dict = {
         'user_output': user_output if isinstance(user_output, tuple) else (user_output,),

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -1,0 +1,34 @@
+import os
+import pickle
+import subprocess
+from ctypes import cdll
+
+run_id = os.path.basename(__file__).split('.')[0]
+input_pickle = "{:s}.input.pickle".format(run_id)
+code_file = "{:s}.c".format(run_id)
+lib_file = "{:s}.so".format(run_id)
+
+with open(input_pickle, mode='rb') as f:
+    input_tuples = pickle.load(f)
+
+# Compile the user's C code.
+# -fPIC for position-independent code, needed for shared libraries to work no matter where in memory they are loaded.
+subprocess.run(["gcc", "-fPIC", "-shared", "-o", lib_file, code_file], check=True)
+
+# Load the compiled shared library.
+cwd = os.path.dirname(os.path.realpath(__file__))
+lib = cdll.LoadLibrary(os.path.join(cwd, lib_file))
+
+for i, input_tuple in enumerate(input_tuples):
+    # $FUNCTION_NAME will be replaced by the name of the user's function by the CodeRunner before this script is run.
+    user_output = lib.$FUNCTION_NAME(*input_tuple)
+
+    output_dict = {
+        'user_output': user_output if isinstance(user_output, tuple) else (user_output,),
+        'runtime': 0,
+        'max_mem_usage': 0
+    }
+
+    output_pickle = '{:s}.output{:d}.pickle'.format(run_id, i)
+    with open(output_pickle, mode='wb') as f:
+        pickle.dump(output_dict, file=f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -3,7 +3,7 @@ import ctypes
 import pickle
 import subprocess
 
-from numpy import ndarray, zeros
+from numpy import array, ndarray, zeros
 from numpy.ctypeslib import ndpointer
 
 def infer_simple_ctype(var):
@@ -76,15 +76,19 @@ def preprocess_types(input_tuple, output_tuple):
         if isinstance(rvar[0], (list, tuple)):
             raise NotImplementedError(f"Cannot infer ctype of a list containing lists or tuples: var={var}")
 
-        arr_ctype = infer_simple_ctype(rvar[0]) * len(rvar)
+        arr = array(rvar)
+
+        arr_ctype = ndpointer(dtype=arr.dtype, flags="C_CONTIGUOUS")
         arg_ctypes.append(arr_ctype)
 
-        arr = arr_ctype()
         input_list.append(arr)
 
         res_ctype = ctypes.c_void_p
 
         output_list.append(arr)
+
+        output_list.append(arr)
+
     elif isinstance(rvar, ndarray):
         arr_ctype = ndpointer(dtype=rvar.dtype, flags="C_CONTIGUOUS")
         arg_ctypes.append(arr_ctype)

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -36,6 +36,9 @@ def ctype_input_list(input_tuple):
 
 def ctype_output(var, correct_output):
     if isinstance(correct_output, str):
+        if not isinstance(var, bytes):
+            raise TypeError("Return type is wrong! Was expecting return type char* (Python bytes). "
+                            "Instead got return type {:}".format(type(var)))
         return var.decode("utf-8")
     else:
         return var

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -51,7 +51,7 @@ def preprocess_types(input_tuple, output_tuple):
             input_list.append(len(var))
 
         elif isinstance(var, ndarray):
-            arr_ctype = ndpointer(dtype=var.dtype, flags="C_CONTIGUOUS")
+            arr_ctype = ndpointer(dtype=var.dtype, ndim=len(var.shape), shape=var.shape, flags="C_CONTIGUOUS")
             arg_ctypes.append(arr_ctype)
             input_list.append(var)
 
@@ -76,7 +76,7 @@ def preprocess_types(input_tuple, output_tuple):
 
             arr = array(rvar)
 
-            arr_ctype = ndpointer(dtype=arr.dtype, flags="C_CONTIGUOUS")
+            arr_ctype = ndpointer(dtype=arr.dtype, ndim=len(arr.shape), shape=arr.shape, flags="C_CONTIGUOUS")
             arg_ctypes.append(arr_ctype)
 
             input_list.append(arr)
@@ -88,7 +88,7 @@ def preprocess_types(input_tuple, output_tuple):
             output_list.append(arr)
 
         elif isinstance(rvar, ndarray):
-            arr_ctype = ndpointer(dtype=rvar.dtype, flags="C_CONTIGUOUS")
+            arr_ctype = ndpointer(dtype=rvar.dtype, ndim=len(rvar.shape), shape=rvar.shape, flags="C_CONTIGUOUS")
             arg_ctypes.append(arr_ctype)
 
             arr = zeros(rvar.shape, dtype=rvar.dtype)

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -1,7 +1,19 @@
 import os
+import ctypes
 import pickle
 import subprocess
-from ctypes import cdll
+
+def infer_argtypes(input_tuple):
+    arg_ctypes = []
+    for var in input_tuple:
+        if isinstance(var, int):
+            arg_ctypes.append(ctypes.c_int)
+        elif isinstance(var, float):
+            arg_ctypes.append(ctypes.c_double)
+        elif isinstance(var, str):
+            arg_ctypes.append(ctypes.c_char_p)
+
+    return arg_ctypes
 
 run_id = os.path.basename(__file__).split('.')[0]
 input_pickle = "{:s}.input.pickle".format(run_id)
@@ -13,11 +25,18 @@ with open(input_pickle, mode='rb') as f:
 
 # Compile the user's C code.
 # -fPIC for position-independent code, needed for shared libraries to work no matter where in memory they are loaded.
+# check=True will raise a CalledProcessError for non-zero return codes (user code failed to compile.)
 subprocess.run(["gcc", "-fPIC", "-shared", "-o", lib_file, code_file], check=True)
 
-# Load the compiled shared library.
+# Load the compiled shared library. We use the absolute path as the cwd is not in LD_LIBRARY_PATH so cdll won't find
+# the .so file if we use a relative path or just a filename.
 cwd = os.path.dirname(os.path.realpath(__file__))
-lib = cdll.LoadLibrary(os.path.join(cwd, lib_file))
+lib = ctypes.cdll.LoadLibrary(os.path.join(cwd, lib_file))
+
+# Use the first input tuple to infer the type of input arguments.
+lib.$FUNCTION_NAME.argtypes = infer_argtypes(input_tuples[0])
+
+lib.$FUNCTION_NAME.restype = ctypes.c_double
 
 for i, input_tuple in enumerate(input_tuples):
     # $FUNCTION_NAME will be replaced by the name of the user's function by the CodeRunner before this script is run.

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -8,6 +8,8 @@ def infer_ctype(var):
         return ctypes.c_int
     elif isinstance(var, float):
         return ctypes.c_double
+    elif isinstance(var, bool):
+        return ctypes.c_bool
     elif isinstance(var, str):
         return ctypes.c_char_p
     else:

--- a/engine/run_c.py
+++ b/engine/run_c.py
@@ -40,8 +40,12 @@ def preprocess_types(input_tuple, output_tuple):
             if isinstance(var[0], (list, tuple)):
                 raise NotImplementedError(f"Cannot infer ctype of a list containing lists or tuples: var={var}")
 
-            arr_ctype = infer_simple_ctype(var[0]) * len(var)
+            elem_ctype = infer_simple_ctype(var[0])
+            arr_ctype = elem_ctype * len(var)
             arg_ctypes.append(arr_ctype)
+
+            if elem_ctype == c_char_p:
+                var = [bytes(s, "utf-8") for s in var]
 
             arr = arr_ctype(*var)
             input_list.append(arr)

--- a/engine/run_jl.py
+++ b/engine/run_jl.py
@@ -18,7 +18,7 @@ for i, input_tuple in enumerate(input_tuples):
 
     if i == 0:
         # Call function to pre/compile. We need to do this if we want accurate performance statistics for the first
-        # test case. $FUNCTION_NAME will be replaced by the name of the user's function by the JuliaRunner
+        # test case. $FUNCTION_NAME will be replaced by the name of the user's function by the CodeRunner
         # before this script is run.
         j.timed_function_call(j.$FUNCTION_NAME, input_tuple)
 

--- a/engine/run_js.py
+++ b/engine/run_js.py
@@ -13,7 +13,7 @@ with open(input_pickle, mode='rb') as f:
 for i, input_tuple in enumerate(input_tuples):
     output_json = "{:s}.output{:d}.json".format(run_id, i)
 
-    # $FUNCTION_NAME will be replaced by the name of the user's function by the JavascriptRunner
+    # $FUNCTION_NAME will be replaced by the name of the user's function by the CodeRunner
     # before this script is run.
     func_call_str = "$FUNCTION_NAME(" + ", ".join([json.dumps(arg) for arg in input_tuple]) + ")"
 
@@ -45,8 +45,6 @@ subprocess.run(["node", code_file])
 
 for i, _ in enumerate(input_tuples):
     output_json = "{:s}.output{:d}.json".format(run_id, i)
-    output_pickle = "{:s}.output{:d}.pickle".format(run_id, i)
-
     with open(output_json, mode='r') as f:
         submission_data = json.loads(f.read())
 
@@ -67,5 +65,6 @@ for i, _ in enumerate(input_tuples):
         'max_mem_usage': max_mem_usage,
     }
 
+    output_pickle = "{:s}.output{:d}.pickle".format(run_id, i)
     with open(output_pickle, mode='wb') as f:
         pickle.dump(output_dict, file=f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/engine/run_py.py
+++ b/engine/run_py.py
@@ -13,12 +13,10 @@ with open(input_pickle, mode='rb') as f:
     input_tuples = pickle.load(f)
 
 for i, input_tuple in enumerate(input_tuples):
-    output_pickle = '{:s}.output{:d}.pickle'.format(run_id, i)
-
     tracemalloc.start()
     t1 = time.time()
 
-    # $FUNCTION_NAME will be replaced by the name of the user's function by the PythonRunner before this script is run.
+    # $FUNCTION_NAME will be replaced by the name of the user's function by the CodeRunner before this script is run.
     user_output = user_module.$FUNCTION_NAME(*input_tuple)
 
     t2 = time.time()
@@ -34,5 +32,6 @@ for i, input_tuple in enumerate(input_tuples):
         'max_mem_usage': max_mem_usage
         }
 
+    output_pickle = '{:s}.output{:d}.pickle'.format(run_id, i)
     with open(output_pickle, mode='wb') as f:
         pickle.dump(output_dict, file=f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/engine/test_api.py
+++ b/engine/test_api.py
@@ -8,7 +8,7 @@ import unittest
 
 
 class TestApi(unittest.TestCase):
-    solutions_dir = "../solutions/"
+    solutions_dir = "/home/ada/lovelace/lovelace-solutions/"
     python_solutions_dir = os.path.join(solutions_dir, "python")
     javascript_solutions_dir = os.path.join(solutions_dir, "javascript")
     julia_solutions_dir = os.path.join(solutions_dir, "julia")
@@ -35,41 +35,41 @@ class TestApi(unittest.TestCase):
 
         return response_data
 
-    # def test_all_problems_python_success(self):
-    #     for relative_filepath in glob.glob(os.path.join(self.python_solutions_dir, "*.py")):
-    #         absolute_filepath = os.path.join(self.python_solutions_dir, os.path.basename(relative_filepath))
-    #
-    #         print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
-    #         t1 = time.perf_counter()
-    #         result = self.submit_solution(absolute_filepath)
-    #         t2 = time.perf_counter()
-    #         print("{:.6f} seconds.".format(t2 - t1))
-    #
-    #         self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
-    #
-    # def test_all_problems_javascript_success(self):
-    #     for relative_filepath in glob.glob(os.path.join(self.javascript_solutions_dir, "*.js")):
-    #         absolute_filepath = os.path.join(self.javascript_solutions_dir, os.path.basename(relative_filepath))
-    #
-    #         print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
-    #         t1 = time.perf_counter()
-    #         result = self.submit_solution(absolute_filepath)
-    #         t2 = time.perf_counter()
-    #         print("{:.6f} seconds.".format(t2 - t1))
-    #
-    #         self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
-    #
-    # def test_all_problems_julia_success(self):
-    #     for relative_filepath in glob.glob(os.path.join(self.julia_solutions_dir, "*.jl")):
-    #         absolute_filepath = os.path.join(self.julia_solutions_dir, os.path.basename(relative_filepath))
-    #
-    #         print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
-    #         t1 = time.perf_counter()
-    #         result = self.submit_solution(absolute_filepath)
-    #         t2 = time.perf_counter()
-    #         print("{:.6f} seconds.".format(t2 - t1))
-    #
-    #         self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
+    def test_all_problems_python_success(self):
+        for relative_filepath in glob.glob(os.path.join(self.python_solutions_dir, "*.py")):
+            absolute_filepath = os.path.join(self.python_solutions_dir, os.path.basename(relative_filepath))
+
+            print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
+            t1 = time.perf_counter()
+            result = self.submit_solution(absolute_filepath)
+            t2 = time.perf_counter()
+            print("{:.6f} seconds.".format(t2 - t1))
+
+            self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
+
+    def test_all_problems_javascript_success(self):
+        for relative_filepath in glob.glob(os.path.join(self.javascript_solutions_dir, "*.js")):
+            absolute_filepath = os.path.join(self.javascript_solutions_dir, os.path.basename(relative_filepath))
+
+            print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
+            t1 = time.perf_counter()
+            result = self.submit_solution(absolute_filepath)
+            t2 = time.perf_counter()
+            print("{:.6f} seconds.".format(t2 - t1))
+
+            self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
+
+    def test_all_problems_julia_success(self):
+        for relative_filepath in glob.glob(os.path.join(self.julia_solutions_dir, "*.jl")):
+            absolute_filepath = os.path.join(self.julia_solutions_dir, os.path.basename(relative_filepath))
+
+            print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
+            t1 = time.perf_counter()
+            result = self.submit_solution(absolute_filepath)
+            t2 = time.perf_counter()
+            print("{:.6f} seconds.".format(t2 - t1))
+
+            self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
 
     def test_all_problems_c_success(self):
         for relative_filepath in glob.glob(os.path.join(self.c_solutions_dir, "*.c")):

--- a/engine/test_api.py
+++ b/engine/test_api.py
@@ -8,18 +8,20 @@ import unittest
 
 
 class TestApi(unittest.TestCase):
-    solutions_dir = '../solutions/'
-    python_solutions_dir = os.path.join(solutions_dir, 'python')
-    javascript_solutions_dir = os.path.join(solutions_dir, 'javascript')
-    julia_solutions_dir = os.path.join(solutions_dir, 'julia')
+    solutions_dir = "../solutions/"
+    python_solutions_dir = os.path.join(solutions_dir, "python")
+    javascript_solutions_dir = os.path.join(solutions_dir, "javascript")
+    julia_solutions_dir = os.path.join(solutions_dir, "julia")
+    c_solutions_dir = os.path.join(solutions_dir, "c")
 
-    def submit_solution(self, file_path):
+    @staticmethod
+    def submit_solution(file_path):
         with open(file_path, 'r') as solution_file:
             code = solution_file.read()
         code_b64 = base64.b64encode(code.encode('utf-8')).decode('utf-8')
 
         problem_name, extension = os.path.basename(file_path).split(sep='.')
-        language = {'py': 'python', 'jl': 'julia', 'js': 'javascript'}.get(extension)
+        language = {'py': "python", 'js': "javascript", 'jl': "julia", 'c': "c"}.get(extension)
 
         payload_dict = {
             'problem': problem_name,
@@ -33,33 +35,45 @@ class TestApi(unittest.TestCase):
 
         return response_data
 
-    def test_all_problems_python_success(self):
-        for relative_filepath in glob.glob(os.path.join(self.python_solutions_dir, "*.py")):
-            absolute_filepath = os.path.join(self.python_solutions_dir, os.path.basename(relative_filepath))
+    # def test_all_problems_python_success(self):
+    #     for relative_filepath in glob.glob(os.path.join(self.python_solutions_dir, "*.py")):
+    #         absolute_filepath = os.path.join(self.python_solutions_dir, os.path.basename(relative_filepath))
+    #
+    #         print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
+    #         t1 = time.perf_counter()
+    #         result = self.submit_solution(absolute_filepath)
+    #         t2 = time.perf_counter()
+    #         print("{:.6f} seconds.".format(t2 - t1))
+    #
+    #         self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
+    #
+    # def test_all_problems_javascript_success(self):
+    #     for relative_filepath in glob.glob(os.path.join(self.javascript_solutions_dir, "*.js")):
+    #         absolute_filepath = os.path.join(self.javascript_solutions_dir, os.path.basename(relative_filepath))
+    #
+    #         print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
+    #         t1 = time.perf_counter()
+    #         result = self.submit_solution(absolute_filepath)
+    #         t2 = time.perf_counter()
+    #         print("{:.6f} seconds.".format(t2 - t1))
+    #
+    #         self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
+    #
+    # def test_all_problems_julia_success(self):
+    #     for relative_filepath in glob.glob(os.path.join(self.julia_solutions_dir, "*.jl")):
+    #         absolute_filepath = os.path.join(self.julia_solutions_dir, os.path.basename(relative_filepath))
+    #
+    #         print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
+    #         t1 = time.perf_counter()
+    #         result = self.submit_solution(absolute_filepath)
+    #         t2 = time.perf_counter()
+    #         print("{:.6f} seconds.".format(t2 - t1))
+    #
+    #         self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
 
-            print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
-            t1 = time.perf_counter()
-            result = self.submit_solution(absolute_filepath)
-            t2 = time.perf_counter()
-            print("{:.6f} seconds.".format(t2 - t1))
-
-            self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
-
-    def test_all_problems_javascript_success(self):
-        for relative_filepath in glob.glob(os.path.join(self.javascript_solutions_dir, "*.js")):
-            absolute_filepath = os.path.join(self.javascript_solutions_dir, os.path.basename(relative_filepath))
-
-            print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
-            t1 = time.perf_counter()
-            result = self.submit_solution(absolute_filepath)
-            t2 = time.perf_counter()
-            print("{:.6f} seconds.".format(t2 - t1))
-
-            self.assertTrue(result['success'], "Failed. Engine output:\n{:}".format(json.dumps(result, indent=4)))
-
-    def test_all_problems_julia_success(self):
-        for relative_filepath in glob.glob(os.path.join(self.julia_solutions_dir, "*.jl")):
-            absolute_filepath = os.path.join(self.julia_solutions_dir, os.path.basename(relative_filepath))
+    def test_all_problems_c_success(self):
+        for relative_filepath in glob.glob(os.path.join(self.c_solutions_dir, "*.c")):
+            absolute_filepath = os.path.join(self.c_solutions_dir, os.path.basename(relative_filepath))
 
             print("Submitting {:}... ".format(absolute_filepath), end="", flush=True)
             t1 = time.perf_counter()


### PR DESCRIPTION
This will take a while.

Very simple C runner right now that works 

Next steps:
* We need to explicitly tell `ctypes` the types of all the arguments. This can be inferred from the `input_tuple` we load from the input pickle file.
* We need to explicitly tell `ctypes` about the types of all the outputs. This will require the engine to somehow communicate the output types to the Linux container. Alternatively, we could solve the test cases before running the user's code just so we can the correct output tuple to infer output data types.

Resolves #20 