### PR TITLE
Modify code runner Dockerfile to support ARM architecture

### DIFF
--- a/code_runner.Dockerfile
+++ b/code_runner.Dockerfile
@@ -10,10 +10,13 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update &&\
     apt-get install -y build-essential curl wget nodejs gnupg
 
+RUN pip install --upgrade pip &&\
+    pip install -r requirements.txt 
+ 
 # Install Julia using the Jill installer script to make sure we get the proper version for this platform
 ENV PATH="/usr/local/bin:${PATH}"
-RUN pip install jill &&\
-    jill install 1.5.3 --upstream Official --confirm &&\
-    julia -e 'import Pkg; Pkg.add("JSON");'
+RUN pip install jill
+RUN jill install 1.5.3 --upstream Official --confirm
+RUN julia -e 'import Pkg; Pkg.add("JSON");'
 
 CMD ["tail", "-f", "/dev/null"]

--- a/code_runner.Dockerfile
+++ b/code_runner.Dockerfile
@@ -8,16 +8,12 @@ ENV PYTHONIOENCODING=utf-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update &&\
-    apt-get install -y build-essential curl wget nodejs
+    apt-get install -y build-essential curl wget nodejs gnupg
 
-RUN pip install --upgrade pip &&\
-    pip install -r requirements.txt
-
-ENV PATH="/root/julia/bin:${PATH}"
-RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.3-linux-x86_64.tar.gz &&\
-    mkdir julia &&\
-    tar xf julia-1.5.3-linux-x86_64.tar.gz -C julia --strip-components 1 &&\
-    rm -rf julia-1.5.3-linux-x86_64.tar.gz &&\
+# Install Julia using the Jill installer script to make sure we get the proper version for this platform
+ENV PATH="/usr/local/bin:${PATH}"
+RUN pip install jill &&\
+    jill install 1.5.3 --upstream Official --confirm &&\
     julia -e 'import Pkg; Pkg.add("JSON");'
 
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
Most of the code runner dockerfile was platform agnostic, but the Julia
installation was using a binary for x86_64 specifically.

I first re-wrote the docker file to use `$(uname -m)` to check the
platform, but the quoting and escaping in the RUN commands were a big
mess. Luckily there's a python tool called Jill which handles installing
Julia from the command line:
https://github.com/abelsiqueira/jill

**This needs tested on an x86 machine!** Unfortunately I don't have ready access to one right now, but maybe the CI pipeline will test this for us?
