### PR TITLE
Only test solutions for problems that exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           docker run -d -v /var/run/docker.sock:/var/run/docker.sock -p 14714:14714 lovelace-engine
           docker ps -a
 
+      - name: Clone lovelace-problems
+        run: |
+          git clone https://github.com/project-lovelace/lovelace-problems.git
+          ln -s lovelace-problems/problems/ problems
+
       - name: Clone lovelace-solutions
         run: |
           git clone https://${{ secrets.LOVELACE_GITHUB_TOKEN }}@github.com/project-lovelace/lovelace-solutions.git
@@ -50,6 +55,7 @@ jobs:
         run: pytest --capture=no --verbose
         env:
           LOVELACE_SOLUTIONS_DIR: ./lovelace-solutions/
+          LOVELACE_PROBLEMS_DIR: ./lovelace-problems/
 
   deploy:
     name: Push Docker image to Docker Hub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: sleep 300
 
       - name: Run tests
-        run: pytest --capture=no --verbose
+        run: pytest --capture=no --verbose tests/
         env:
           LOVELACE_SOLUTIONS_DIR: ./lovelace-solutions/
           LOVELACE_PROBLEMS_DIR: ./lovelace-problems/

--- a/.gitignore
+++ b/.gitignore
@@ -99,9 +99,11 @@ resources
 # IDE files
 .idea
 
-# Symlinks
+# Symlinks and other repos
 lovelace-solutions
+lovelace-problems
 solutions
+problems
 
 # Secrets
 token.txt

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,10 +1,11 @@
 import os
+import glob
 
-# User can set solutions dir and server/port for lovelace engine if it's different from
-# the default. Don't forget http:// at the beginning of the engine URI
+# User can set solutions and problems dir and server/port for lovelace engine if it's different
+# from the default. Don't forget http:// at the beginning of the engine URI
 # export LOVELACE_ENGINE_URI="https://custom-url:12345"
 # export LOVELACE_SOLUTIONS_DIR="/home/myuser/lovelace/solutions"
-
+# export LOVELACE_PROBLEMS_DIR="/home/myuser/lovelace/problems"
 
 def solutions_dir(language=""):
     sol_dir = os.environ.get("LOVELACE_SOLUTIONS_DIR", "/home/ada/lovelace/lovelace-solutions/")
@@ -12,7 +13,41 @@ def solutions_dir(language=""):
         sol_dir = os.path.join(sol_dir, language)
     if not os.path.isdir(sol_dir):
         raise ValueError(
-            "Cannot find solutions dir at: {}. "
-            "Is the env var LOVELACE_SOLUTIONS_DIR set properly?".format(sol_dir)
+            f"Cannot find solutions dir at: {sol_dir}. "
+            "Is the env var LOVELACE_SOLUTIONS_DIR set properly?"
         )
     return sol_dir
+
+def problems_dir():
+    prob_dir = os.environ.get("LOVELACE_PROBLEMS_DIR", "/home/ada/lovelace/lovelace-problems/")
+    if not os.path.isdir(prob_dir):
+        raise ValueError(
+            f"Cannot find solutions dir at: {prob_dir}. "
+            "Is the env var LOVELACE_PROBLEMS_DIR set properly?"
+        )
+    return prob_dir
+
+
+language2ext = {"python": "py", "javascript": "js", "julia": "jl", "c": "c"}
+
+
+def get_solution_filepaths(language=""):
+    all_solution_filepaths = glob.glob(os.path.join(solutions_dir(language), f"*.{language2ext[language]}"))
+    all_problem_filepaths = glob.glob(os.path.join(problems_dir(), "problems", "*.py"))
+
+    solutions = [os.path.splitext(os.path.basename(fp))[0] for fp in all_solution_filepaths]
+    problems = [os.path.splitext(os.path.basename(fp))[0] for fp in all_problem_filepaths]
+
+    valid_solution_filepaths = []
+
+    for (n, sol) in enumerate(solutions):
+        # Might need to replace - with _ for Javascript solutions.
+        if sol.replace("-", "_") in problems:
+            valid_solution_filepaths.append(all_solution_filepaths[n])
+
+    return valid_solution_filepaths
+
+
+def id_func(param):
+    problem_name, ext = os.path.splitext(os.path.basename(param))
+    return problem_name

--- a/tests/test_c_solutions.py
+++ b/tests/test_c_solutions.py
@@ -1,27 +1,18 @@
-import glob
 import json
-import os
-
 import pytest
 
-from helpers import solutions_dir
+from helpers import get_solution_filepaths, id_func
 
 
-# NOTE: If we make solution_files a fixture instead of a normal attr/function,
-# then we can't use it in pytest's parametrize
-solution_files = glob.glob(os.path.join(solutions_dir("c"), "*.c"))
+solution_files = get_solution_filepaths(language="c")
 
 # Don't test game_of_life.c for now.
 solution_files = list(filter(lambda s: "game_of_life" not in s, solution_files))
 
+
 @pytest.mark.c
 def test_c_solutions_exist():
     assert solution_files
-
-
-def id_func(param):
-    problem_name, ext = os.path.splitext(os.path.basename(param))
-    return problem_name
 
 
 @pytest.mark.c

--- a/tests/test_javascript_solutions.py
+++ b/tests/test_javascript_solutions.py
@@ -1,25 +1,15 @@
-import glob
 import json
-import os
-
 import pytest
 
-from helpers import solutions_dir
+from helpers import get_solution_filepaths, id_func
 
 
-# NOTE: If we make solution_files a fixture instead of a normal attr/function,
-# then we can't use it in pytest's parametrize
-solution_files = glob.glob(os.path.join(solutions_dir("javascript"), "*.js"))
+solution_files = get_solution_filepaths(language="javascript")
 
 
 @pytest.mark.javascript
 def test_javascript_solutions_exist():
     assert solution_files
-
-
-def id_func(param):
-    problem_name, ext = os.path.splitext(os.path.basename(param))
-    return problem_name
 
 
 @pytest.mark.javascript

--- a/tests/test_julia_solutions.py
+++ b/tests/test_julia_solutions.py
@@ -1,25 +1,15 @@
-import glob
 import json
-import os
-
 import pytest
 
-from helpers import solutions_dir
+from helpers import get_solution_filepaths, id_func
 
 
-# NOTE: If we make solution_files a fixture instead of a normal attr/function,
-# then we can't use it in pytest's parametrize
-solution_files = glob.glob(os.path.join(solutions_dir("julia"), "*.jl"))
+solution_files = get_solution_filepaths(language="julia")
 
 
 @pytest.mark.julia
 def test_julia_solutions_exist():
     assert solution_files
-
-
-def id_func(param):
-    problem_name, ext = os.path.splitext(os.path.basename(param))
-    return problem_name
 
 
 @pytest.mark.julia

--- a/tests/test_python_solutions.py
+++ b/tests/test_python_solutions.py
@@ -1,25 +1,15 @@
-import glob
 import json
-import os
-
 import pytest
 
-from helpers import solutions_dir
+from helpers import get_solution_filepaths, id_func
 
 
-# NOTE: If we make solution_files a fixture instead of a normal attr/function,
-# then we can't use it in pytest's parametrize
-solution_files = glob.glob(os.path.join(solutions_dir("python"), "*.py"))
+solution_files = get_solution_filepaths(language="python")
 
 
 @pytest.mark.python
 def test_python_solutions_exist():
     assert solution_files
-
-
-def id_func(param):
-    problem_name, ext = os.path.splitext(os.path.basename(param))
-    return problem_name
 
 
 @pytest.mark.python


### PR DESCRIPTION
Right now tests are failing because there's a Python solution for `numerical_diff` but no problem module for `numerical_diff` so the engine fails a test.

This PR makes the engine tests more robust to this by only testing solutions for problems that exist.