### PR TITLE
Ability to test dummy solutions not from lovelace-solutions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def submit_solution(engine_submit_uri):
 
 
 @pytest.fixture()
-def submit_solution(engine_submit_uri):
+def submit_file(engine_submit_uri):
     def _submit_solution(file_path, problem, language):
         with open(file_path, "r") as solution_file:
             code = solution_file.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,3 +52,23 @@ def submit_solution(engine_submit_uri):
         return response.json()
 
     return _submit_solution
+
+
+@pytest.fixture()
+def submit_solution(engine_submit_uri):
+    def _submit_solution(file_path, problem, language):
+        with open(file_path, "r") as solution_file:
+            code = solution_file.read()
+        code_b64 = base64.b64encode(code.encode("utf-8")).decode("utf-8")
+
+        payload_dict = {"problem": problem, "language": language, "code": code_b64}
+        payload_json = json.dumps(payload_dict)
+
+        t1 = time.perf_counter()
+        response = requests.post(engine_submit_uri, data=payload_json)
+        t2 = time.perf_counter()
+        print(f"{t2 - t1 : .6f} seconds ", end='')
+
+        return response.json()
+
+    return _submit_solution

--- a/tests/dummy_solutions/chaos.js
+++ b/tests/dummy_solutions/chaos.js
@@ -1,0 +1,10 @@
+fs = require('fs');
+
+function logistic_map(r) {
+  let x = [0.5];
+  for (let i = 0; i < 50; i++) {
+    let last = x[x.length - 1];
+    x.push(r * last * (1 - last));
+  }
+  return [x];
+}

--- a/tests/dummy_solutions/chaos.js
+++ b/tests/dummy_solutions/chaos.js
@@ -1,4 +1,4 @@
-fs = require('fs');
+const fs = require('fs');
 
 function logistic_map(r) {
   let x = [0.5];

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,6 +29,7 @@ def problems_dir():
 
 
 language2ext = {"python": "py", "javascript": "js", "julia": "jl", "c": "c"}
+ext2language = {"py": "python", "js": "javascript", "jl": "julia", "c": "c"}
 
 
 def get_solution_filepaths(language=""):
@@ -48,6 +49,10 @@ def get_solution_filepaths(language=""):
     return valid_solution_filepaths
 
 
-def id_func(param):
+def problem_name_id(param):
     problem_name, ext = os.path.splitext(os.path.basename(param))
     return problem_name
+
+
+def filename_id(param):
+    return os.path.basename(param)

--- a/tests/test_c_solutions.py
+++ b/tests/test_c_solutions.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from helpers import get_solution_filepaths, id_func
+from helpers import get_solution_filepaths, problem_name_id
 
 
 solution_files = get_solution_filepaths(language="c")
@@ -16,7 +16,7 @@ def test_c_solutions_exist():
 
 
 @pytest.mark.c
-@pytest.mark.parametrize("solution_file", solution_files, ids=id_func)
+@pytest.mark.parametrize("solution_file", solution_files, ids=problem_name_id)
 def test_submit_file(solution_file, submit_solution):
     result = submit_solution(solution_file)
 

--- a/tests/test_dummy_solutions.py
+++ b/tests/test_dummy_solutions.py
@@ -1,0 +1,20 @@
+import os
+import glob
+import json
+import pytest
+
+from helpers import filename_id, ext2language
+
+
+cwd = os.path.dirname(os.path.realpath(__file__))
+solution_files = glob.glob(os.path.join(cwd, "dummy_solutions", "*"))
+
+
+@pytest.mark.parametrize("solution_file", solution_files, ids=filename_id)
+def test_dummy_solutions(solution_file, submit_solution):
+    problem_name, ext = os.path.splitext(os.path.basename(solution_file))
+    result = submit_solution(solution_file, problem_name, ext2language[ext[1:]])
+
+    assert result.get("success") is True, "Failed. Engine output:\n{:}".format(
+        json.dumps(result, indent=4)
+    )

--- a/tests/test_dummy_solutions.py
+++ b/tests/test_dummy_solutions.py
@@ -13,7 +13,7 @@ solution_files = glob.glob(os.path.join(cwd, "dummy_solutions", "*"))
 @pytest.mark.parametrize("solution_file", solution_files, ids=filename_id)
 def test_dummy_solutions(solution_file, submit_solution):
     problem_name, ext = os.path.splitext(os.path.basename(solution_file))
-    result = submit_solution(solution_file, problem_name, ext2language[ext[1:]])
+    result = submit_file(solution_file, problem_name, ext2language[ext[1:]])
 
     assert result.get("success") is True, "Failed. Engine output:\n{:}".format(
         json.dumps(result, indent=4)

--- a/tests/test_dummy_solutions.py
+++ b/tests/test_dummy_solutions.py
@@ -11,7 +11,7 @@ solution_files = glob.glob(os.path.join(cwd, "dummy_solutions", "*"))
 
 
 @pytest.mark.parametrize("solution_file", solution_files, ids=filename_id)
-def test_dummy_solutions(solution_file, submit_solution):
+def test_dummy_solutions(solution_file, submit_file):
     problem_name, ext = os.path.splitext(os.path.basename(solution_file))
     result = submit_file(solution_file, problem_name, ext2language[ext[1:]])
 

--- a/tests/test_javascript_solutions.py
+++ b/tests/test_javascript_solutions.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from helpers import get_solution_filepaths, id_func
+from helpers import get_solution_filepaths, problem_name_id
 
 
 solution_files = get_solution_filepaths(language="javascript")
@@ -13,7 +13,7 @@ def test_javascript_solutions_exist():
 
 
 @pytest.mark.javascript
-@pytest.mark.parametrize("solution_file", solution_files, ids=id_func)
+@pytest.mark.parametrize("solution_file", solution_files, ids=problem_name_id)
 def test_submit_file(solution_file, submit_solution):
     result = submit_solution(solution_file)
 

--- a/tests/test_julia_solutions.py
+++ b/tests/test_julia_solutions.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from helpers import get_solution_filepaths, id_func
+from helpers import get_solution_filepaths, problem_name_id
 
 
 solution_files = get_solution_filepaths(language="julia")
@@ -13,7 +13,7 @@ def test_julia_solutions_exist():
 
 
 @pytest.mark.julia
-@pytest.mark.parametrize("solution_file", solution_files, ids=id_func)
+@pytest.mark.parametrize("solution_file", solution_files, ids=problem_name_id)
 def test_submit_file(solution_file, submit_solution):
     result = submit_solution(solution_file)
 

--- a/tests/test_python_solutions.py
+++ b/tests/test_python_solutions.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from helpers import get_solution_filepaths, id_func
+from helpers import get_solution_filepaths, problem_name_id
 
 
 solution_files = get_solution_filepaths(language="python")
@@ -13,7 +13,7 @@ def test_python_solutions_exist():
 
 
 @pytest.mark.python
-@pytest.mark.parametrize("solution_file", solution_files, ids=id_func)
+@pytest.mark.parametrize("solution_file", solution_files, ids=problem_name_id)
 def test_submit_file(solution_file, submit_solution):
     result = submit_solution(solution_file)
 


### PR DESCRIPTION
@BinaryFissionGames Following up from #86 this PR allows us to test solutions not from the lovelace-solutions repo. So I added a dummy solution that uses `const fs = require('fs');` which now passes!

Should be useful for testing more solutions, not just the "perfect" ones from lovelace-solutions.

Resolves #87