### PR TITLE
Fix how Javascript runner interprets lists

### DIFF
--- a/engine/api.py
+++ b/engine/api.py
@@ -229,6 +229,17 @@ class SubmitResource:
         for input_tuple, user_output, p_info, tc in zip(
             input_tuples, user_outputs, p_infos, test_cases
         ):
+
+            if isinstance(user_output, list):
+                # user_output is a list. This could be a multiple-return, or a legitimate list return.
+                # Here we will disambiguate dependant on the output variables the problem requires
+                if len(problem.OUTPUT_VARS) == 1:
+                    # Only one variable should be returned; Thus, this is a "list return"
+                    user_output = (user_output,)
+                else:
+                    # More than one variable should be returned, so this is a multiple return
+                    user_output = tuple(user_output)
+
             if user_output[0] is None:
                 logger.debug(
                     "Looks like user's function returned None: output={:}".format(user_output)

--- a/engine/run_js.py
+++ b/engine/run_js.py
@@ -54,12 +54,8 @@ for i, _ in enumerate(input_tuples):
     runtime = submission_data['runTime']
     max_mem_usage = submission_data['maxMemoryUsage']
 
-    if isinstance(user_output, list) and len(user_output) == 1 and isinstance(user_output[0], list):
-        user_output = (user_output[0],)  # Solution is a list
-    elif isinstance(user_output, list):
-        user_output = tuple(user_output)  # Solution is a "multiple return"
-    else:
-        user_output = (user_output,)  # Solution is a string or number
+    if not isinstance(user_output, list):
+        user_output = (user_output,)  # Solution is a string, number, or dict, meaning it is a single-value return.
 
     output_dict = {
         'user_output': user_output,

--- a/tests/dummy_solutions/chaos.js
+++ b/tests/dummy_solutions/chaos.js
@@ -6,5 +6,5 @@ function logistic_map(r) {
     let last = x[x.length - 1];
     x.push(r * last * (1 - last));
   }
-  return [x];
+  return x;
 }


### PR DESCRIPTION
@BinaryFissionGames I modified the test solution of `chaos.js` to `return x;` instead of `return [x];` so tests should fail.

Hopefully we can find a way of resolving #85 after which the tests should all pass.